### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ In other words, `quarto-preprint` should provide a reliable and fuss-free Quarto
 Add template to an existing project:
 
 ```bash
-quarto add template mvuorre/preprint
+quarto add template mvuorre/quarto-preprint
 ```
 
 Start a new Quarto project that uses `quarto-preprint`:
 
 ```bash
-quarto use template mvuorre/preprint
+quarto use template mvuorre/quarto-preprint
 ```
 
 ## Use


### PR DESCRIPTION
I tried to use this template today and noticed that there was a typo in the cli commands. With this fix people can just copy and paste. 