### PR TITLE
Prevent line break in authors name

### DIFF
--- a/_extensions/preprint/typst-template.typ
+++ b/_extensions/preprint/typst-template.typ
@@ -47,12 +47,12 @@
     for a in authors {
       let author_string = [
         // Solo manuscripts don't have institutional id
-        #a.name#if authors.len() > 1 [#super[#a.affiliation]]#if a.keys().contains("email") {[\*]}
+        #box[#a.name]#if authors.len() > 1 [#super[#a.affiliation]]#if a.keys().contains("email") {[\*]}
         #if a.keys().contains("orcid") {
             box(
               height: 1em,
               link(
-                a.orcid, 
+                a.orcid,
                 figure(
                   image("orcid.svg", height: 0.9em)
                 )
@@ -69,7 +69,7 @@
 
   // Page settings (including headers & footers)
   set page(
-    paper: paper, 
+    paper: paper,
     margin: margin,
     numbering: "1",
     header-ascent: 50%,
@@ -110,10 +110,10 @@
         }
     )
   )
-  
+
   // Paragraph settings
   set par(
-    justify: true, 
+    justify: true,
     leading: leading,
     first-line-indent: first-line-indent
   )
@@ -155,24 +155,24 @@
   show heading.where(
     level: 4
   ): it => box(
-    inset: (top: 0em, bottom: 0em, left: 0em, right: 1em), 
+    inset: (top: 0em, bottom: 0em, left: 0em, right: 1em),
     text(size: 1em, weight: "bold", it)
   )
   show heading.where(
     level: 5
   ): it => box(
-    inset: (top: 0em, bottom: 0em, left: 0em, right: 1em), 
+    inset: (top: 0em, bottom: 0em, left: 0em, right: 1em),
     text(size: 1em, weight: "bold", style: "italic", it)
   )
 
   /* Content front matter */
 
   let titleblock(
-    body, 
-    width: 100%, 
-    size: 1.5em, 
-    weight: "bold", 
-    above: 1em, 
+    body,
+    width: 100%,
+    size: 1.5em,
+    weight: "bold",
+    above: 1em,
     below: 0em
   ) = [
     #align(center)[
@@ -201,7 +201,7 @@
       ]
     )
   }
-  
+
   // Abstract and keywords block
   block(inset: (top: 2em, bottom: 0em, left: 2.4em, right: 2.4em))[
     #set text(size: 0.92em)
@@ -243,14 +243,14 @@
 
   // Separate content a bit from front matter
   v(2em)
-  
+
   // Show document content with cols if specified
   if cols == 1 {
     doc
   } else {
     columns(
-      cols, 
-      gutter: col-gutter, 
+      cols,
+      gutter: col-gutter,
       doc
     )
   }
@@ -260,5 +260,5 @@
 // Remove gridlines from tables
 #set table(
   inset: 6pt,
-  stroke: none
+  stroke: none,
 )


### PR DESCRIPTION
When there is many authors there might be awkward situation when author first name and surname is split between lines, this change wraps `#a.name` inside `#box[...]` to prevent that 